### PR TITLE
Fix: Error opening video when using a short url

### DIFF
--- a/YDL-UI/Utility/GuiUtil.cs
+++ b/YDL-UI/Utility/GuiUtil.cs
@@ -176,10 +176,16 @@
 
                 DataGridViewCell cell = dgv.Rows[e.RowIndex].Cells[e.ColumnIndex];
                 if (cell is DataGridViewLinkCell) {
+
+                    string urlLink = (cell.Value as string).Trim();
+
+                    if (!urlLink.StartsWith("https://www.youtube.com"))
+                        urlLink = string.Format("https://www.youtube.com/watch?v={0}", urlLink);
+
                     if (action != null) {
-                        action(new Uri(cell.Value as string));
+                        action(new Uri(urlLink));
                     } else {
-                        Process.Start(cell.Value as string);
+                        Process.Start(urlLink);
                     }
                 }
             };


### PR DESCRIPTION
When a video from the download list was inserted in short url format, the application could not open it in the browser and ended up causing an unhandled error. This PR aims to fix that.

Exemple:

❌ EmGFdalXd-w -> Causes Error
✅ https://www.youtube.com/watch?v=EmGFdalXd-w -> It works perfectly

Just treated so that if the video URL doesn't start with "https://www.youtube.com/watch?v=", this is inserted at the beginning, making it a valid Youtube link.

EmGFdalXd-w -> https://www.youtube.com/watch?v=EmGFdalXd-w

Ref. Issue: #102 